### PR TITLE
Change ActiveSupport::EventedFileUpdateChecker

### DIFF
--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -50,5 +50,5 @@ Rails.application.configure do
 
   # Use an evented file watcher to asynchronously detect changes in source code,
   # routes, locales, etc. This feature depends on the listen gem.
-  config.file_watcher = ActiveSupport::EventedFileUpdateChecker
+  config.file_watcher = ActiveSupport::FileUpdateChecker
 end


### PR DESCRIPTION
We change 'ActiveSupport::EventedFileUpdateChecker' to
'ActiveSupport::FileUpdateChecker' because FileUpdateChecker will detect
by polling the change of the file.