### PR TITLE
Exclude coverage folder

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,3 +31,6 @@ public/uploads/
 .vagrant/
 
 vendor/bundle
+
+# Coverage
+coverage/


### PR DESCRIPTION
To avoid that it apears everytime the tests are running locally. :bowtie: 