### PR TITLE
Refactor github pull requests in dashboard

### DIFF
--- a/app/controllers/dashboards_controller.rb
+++ b/app/controllers/dashboards_controller.rb
@@ -5,8 +5,12 @@ class DashboardsController < ApplicationController
     @absences = Absence.current
     @meetings = Meeting.today
     pull_requests = PullRequest.from_github_repository('openSUSE/open-build-service')
-    @backend_pull_requests = pull_requests.select { |pr| pr.labeled?('Backend') }
-    @webui_pull_requests = pull_requests.reject { |pr| pr.labeled?('Backend') }
+    @pull_requests = {}
+    @pull_requests[:backend] = pull_requests.select { |pr| pr.labeled?('Backend') }
+    @pull_requests[:webui] = pull_requests.reject { |pr| pr.labeled?('Backend') }
+    @pull_requests[:documentation] = PullRequest.from_github_repository('openSUSE/obs-docu')
+    @pull_requests[:landing] = PullRequest.from_github_repository('openSUSE/obs-landing')
+    @pull_requests[:dashboard] = PullRequest.from_github_repository('openSUSE/agile-team-dashboard')
     @public_holidays = Holidays.between(Time.zone.today.beginning_of_week,
                                         Time.zone.today.end_of_week,
                                         %i(es gb cz))

--- a/app/models/pull_request.rb
+++ b/app/models/pull_request.rb
@@ -17,7 +17,7 @@ class PullRequest
 
   def self.from_github_repository(repository)
     Rails.cache.fetch("github_pull_requests_for_#{repository}", expires_in: 10.minutes) do
-      Rails.logger.info('>>> Consulting GitHub PRs......')
+      Rails.logger.info(">>> Consulting GitHub PRs for #{repository}......")
       pull_requests = github_api_get("https://api.github.com/repos/#{repository}/pulls")
       return [] unless pull_requests.is_a?(Array)
       pull_requests.map { |pull_request| new_from_github(repository, pull_request) }

--- a/app/views/dashboards/index.html.slim
+++ b/app/views/dashboards/index.html.slim
@@ -65,17 +65,50 @@
     .column
       .eight.wide.column
         h3.ui.top.attached.header
+          ' Github Pull Requests
+          .ui.hidden.divider
           .ui.secondary.menu
             a.item.active data-tab= "webui"
-              .ui.red.horizontal.label= @webui_pull_requests.count
-              | WebUI Pull Requests
+              .ui.blue.horizontal.label= @pull_requests[:webui].count
+              | WebUI
+            .ui.flowing.popup.top.left.transition.hidden
+              a href="https://github.com/openSUSE/open-build-service/pulls" target='_blank'
+                ' open-build-service
             a.item data-tab= "backend"
-              .ui.teal.horizontal.label= @backend_pull_requests.count
-              ' Backend Pull Requests
+              .ui.teal.horizontal.label= @pull_requests[:backend].count
+              ' Backend
+            .ui.flowing.popup.top.left.transition.hidden
+              a href="https://github.com/openSUSE/open-build-service/pulls" target='_blank'
+                ' open-build-service
+            a.item data-tab= "documentation"
+              .ui.black.horizontal.label= @pull_requests[:documentation].count
+              ' Documentation
+            .ui.flowing.popup.top.left.transition.hidden
+              a href="https://github.com/openSUSE/obs-docu/pulls" target='_blank'
+                ' obs-docu
+            a.item data-tab= "landing"
+              .ui.purple.horizontal.label= @pull_requests[:landing].count
+              ' Landing
+            .ui.flowing.popup.top.left.transition.hidden
+              a href="https://github.com/openSUSE/obs-landing/pulls" target='_blank'
+                ' obs-landing
+            a.item data-tab= "dashboard"
+              .ui.olive.horizontal.label= @pull_requests[:dashboard].count
+              ' Dashboard
+            .ui.flowing.popup.top.left.transition.hidden
+              a href="https://github.com/openSUSE/agile-team-dashboard/pulls" target='_blank'
+                ' agile-team-dashboard
         .ui.bottom.relaxed.divided.list.attached.tab.segment.active.pull_requests data-tab= "webui"
-          = render partial: 'pull_requests', locals: { pull_requests: @webui_pull_requests }
+          = render partial: 'pull_requests', locals: { pull_requests: @pull_requests[:webui] }
         .ui.bottom.relaxed.divided.list.attached.tab.segment.pull_requests data-tab= "backend"
-          = render partial: 'pull_requests', locals: { pull_requests: @backend_pull_requests }
+          = render partial: 'pull_requests', locals: { pull_requests: @pull_requests[:backend] }
+        .ui.bottom.relaxed.divided.list.attached.tab.segment.pull_requests data-tab= "documentation"
+          = render partial: 'pull_requests', locals: { pull_requests: @pull_requests[:documentation] }
+        .ui.bottom.relaxed.divided.list.attached.tab.segment.pull_requests data-tab= "landing"
+          = render partial: 'pull_requests', locals: { pull_requests: @pull_requests[:landing] }
+        .ui.bottom.relaxed.divided.list.attached.tab.segment.pull_requests data-tab= "dashboard"
+          = render partial: 'pull_requests', locals: { pull_requests: @pull_requests[:dashboard] }
         .ui.bottom.attached.header
 javascript:
   $('.menu .item').tab();
+  $('.menu .item').popup({hoverable: true});


### PR DESCRIPTION
Added more repositories (obs-docu, obs-landing, agile-team-dashboard) for showing the pull requests

Now it looks like that:
![image](https://user-images.githubusercontent.com/11314634/29967048-f26dba4e-8f14-11e7-98d7-71789f1015d5.png)
