### PR TITLE
Git cop

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ dist: trusty
 language: ruby
 cache: bundler
 rvm:
-  - 2.3.1
+  - 2.4
 before_install:
   - "echo 'gem: --no-ri --no-rdoc' > ~/.gemrc"
   - "echo `phantomjs -v`"

--- a/Gemfile
+++ b/Gemfile
@@ -62,6 +62,8 @@ group :test do
   # for test coverage reports
   gem 'codecov', require: false
   gem 'simplecov', require: false
+  # for checking commit messages
+  gem 'git-cop'
 end
 
 group :development, :test do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -102,6 +102,7 @@ GEM
       warden (~> 1.2.3)
     diff-lcs (1.3)
     docile (1.1.5)
+    equatable (0.5.0)
     erubi (1.6.1)
     execjs (2.7.0)
     factory_girl (4.8.0)
@@ -118,6 +119,11 @@ GEM
       jquery-rails (>= 4.0.5, < 5.0.0)
       jquery-ui-rails (>= 5.0.2)
       momentjs-rails (>= 2.9.0)
+    git-cop (1.6.0)
+      pastel (~> 0.7)
+      refinements (~> 4.2)
+      runcom (~> 1.3)
+      thor (~> 0.20)
     globalid (0.4.0)
       activesupport (>= 4.2.0)
     holidays (6.1.0)
@@ -178,6 +184,9 @@ GEM
     passenger (5.1.8)
       rack
       rake (>= 0.8.1)
+    pastel (0.7.1)
+      equatable (~> 0.5.0)
+      tty-color (~> 0.4.0)
     pg (0.21.0)
     phantomjs (2.1.1.0)
     poltergeist (1.16.0)
@@ -236,6 +245,7 @@ GEM
     rb-inotify (0.9.10)
       ffi (>= 0.5.0, < 2)
     ref (2.0.0)
+    refinements (4.2.0)
     responders (2.4.0)
       actionpack (>= 4.2.0, < 5.3)
       railties (>= 4.2.0, < 5.3)
@@ -267,6 +277,8 @@ GEM
       ruby-progressbar (~> 1.7)
       unicode-display_width (~> 1.0, >= 1.0.1)
     ruby-progressbar (1.8.1)
+    runcom (1.3.0)
+      refinements (~> 4.2)
     sass (3.5.1)
       sass-listen (~> 4.0.0)
     sass-listen (4.0.0)
@@ -325,6 +337,7 @@ GEM
     thread_safe (0.3.6)
     tilt (2.0.8)
     timecop (0.9.1)
+    tty-color (0.4.2)
     turbolinks (5.0.1)
       turbolinks-source (~> 5)
     turbolinks-source (5.0.3)
@@ -365,6 +378,7 @@ DEPENDENCIES
   faker
   flag-icon-sass
   fullcalendar-rails
+  git-cop
   holidays
   identicon
   jbuilder (~> 2.5)

--- a/git-cop_configuration.yml
+++ b/git-cop_configuration.yml
@@ -1,0 +1,61 @@
+:commit_author_email:
+  :enabled: true
+  :severity: :error
+:commit_author_name_capitalization:
+  :enabled: false
+:commit_author_name_parts:
+  :enabled: false
+:commit_body_bullet:
+  :enabled: true
+  :severity: :warn
+  :blacklist:
+    - "\\*"
+    - "•"
+:commit_body_bullet_capitalization:
+  :enabled: false
+:commit_body_issue_tracker_link:
+  :enabled: false
+:commit_body_leading_line:
+  :enabled: true
+  :severity: :error
+:commit_body_leading_space:
+  :enabled: false
+:commit_body_line_length:
+  :enabled: true
+  :severity: :warn
+  :length: 72
+:commit_body_paragraph_capitalization:
+  :enabled: false
+:commit_body_phrase:
+  :enabled: true
+  :severity: :warn
+  :blacklist:
+    - obviously
+    - basically
+    - simply
+    - of course
+    - everyone knows
+    - easy
+:commit_body_presence:
+  :enabled: true
+  :severity: :error
+  :minimum: 1
+:commit_body_single_bullet:
+  :enabled: false
+:commit_subject_length:
+  :enabled: true
+  :severity: :error
+  :length: 60
+:commit_subject_prefix:
+  :enabled: true
+  :severity: :error
+  :whitelist:
+    - Add
+    - Change
+    - Disable
+    - Enable
+    - Remove
+    - Use
+    - Update
+:commit_subject_suffix:
+  :enabled: false

--- a/lib/tasks/git-cop.rake
+++ b/lib/tasks/git-cop.rake
@@ -1,0 +1,8 @@
+desc 'Run Git-cop locally'
+task :git_cop do
+  puts "\nCopying configuration file into ~/.config/git-cop/configuration.yml"
+  sh "mkdir -p ~/.config/git-cop"
+  sh "cp git-cop_configuration.yml ~/.config/git-cop/configuration.yml"
+  puts
+  sh "bundle exec git-cop --police"
+end

--- a/travis_script.sh
+++ b/travis_script.sh
@@ -15,6 +15,7 @@ case $TEST_SUITE in
   linters)
     bundle exec rubocop -Dc .rubocop.yml
     bundle exec slim-lint .
+    bundle exec rake git_cop
     jshint .
     ;;
   rspec)


### PR DESCRIPTION
Add git-cop to help us to write better commits. I also implemented a rake task to run it locally and configure Travis to run it together with the others linters. :bowtie: 

The enabled cops with error severity are:

- **commit_author_email** Ensures author email address exists

- **commit_body_leading_line** Ensures there is a leading, empty line, between the commit subject and body

- **commit_body_presence** Ensure that there is a commit description

- **commit_subject_length** Ensures the commit subject length is no more than 60 characters in length

- **commit_subject_prefix** Ensures the commit subject uses one of the following prefixes: _ Add_, _Change_, _Disable_, _Enable_, _Remove_, _Use_, _Update_. This help us to have consistent prefixes that help explaining what is being commited

Some other enabled with warning severity, which means they won't make the test fail.

Closes https://github.com/openSUSE/agile-team-dashboard/issues/37