### PR TITLE
Burndown chart - New Sprint

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,3 +34,6 @@ vendor/bundle
 
 # Coverage
 coverage/
+
+# Trello keys
+trollolo/.trollolorc

--- a/Gemfile
+++ b/Gemfile
@@ -45,6 +45,8 @@ gem 'flag-icon-sass'
 gem 'identicon'
 gem 'redcarpet'
 
+gem 'trollolo', git: 'https://github.com/Ana06/trollolo', branch: 'bug'
+
 # Use Capistrano for deployment
 # gem 'capistrano-rails', group: :development
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,4 +1,13 @@
 GIT
+  remote: https://github.com/Ana06/trollolo
+  revision: e47f7d5f327235cd74e57856a46a74067c71b407
+  branch: bug
+  specs:
+    trollolo (0.0.14)
+      ruby-trello (~> 1.5.0)
+      thor (~> 0.19)
+
+GIT
   remote: https://github.com/ctran/annotate_models.git
   revision: 5f37a974f3dff68f92b3495115f1399e7db5c584
   specs:
@@ -102,6 +111,8 @@ GEM
       warden (~> 1.2.3)
     diff-lcs (1.3)
     docile (1.1.5)
+    domain_name (0.5.20170404)
+      unf (>= 0.0.5, < 1.0.0)
     equatable (0.5.0)
     erubi (1.6.1)
     execjs (2.7.0)
@@ -127,6 +138,8 @@ GEM
     globalid (0.4.0)
       activesupport (>= 4.2.0)
     holidays (6.1.0)
+    http-cookie (1.0.3)
+      domain_name (~> 0.5)
     i18n (0.8.6)
     i18n_data (0.8.0)
     identicon (0.0.5)
@@ -164,9 +177,7 @@ GEM
     mail (2.6.6)
       mime-types (>= 1.16, < 4)
     method_source (0.8.2)
-    mime-types (3.1)
-      mime-types-data (~> 3.2015)
-    mime-types-data (3.2016.0521)
+    mime-types (2.99.3)
     mini_mime (0.1.4)
     mini_portile2 (2.2.0)
     minitest (5.10.3)
@@ -175,9 +186,11 @@ GEM
     money (6.9.0)
       i18n (>= 0.6.4, < 0.9)
     multi_json (1.12.1)
+    netrc (0.11.0)
     nio4r (2.1.0)
     nokogiri (1.8.0)
       mini_portile2 (~> 2.2.0)
+    oauth (0.5.3)
     orm_adapter (0.5.0)
     parser (2.4.0.0)
       ast (~> 2.2)
@@ -250,6 +263,10 @@ GEM
     responders (2.4.0)
       actionpack (>= 4.2.0, < 5.3)
       railties (>= 4.2.0, < 5.3)
+    rest-client (1.8.0)
+      http-cookie (>= 1.0.2, < 2.0)
+      mime-types (>= 1.16, < 3.0)
+      netrc (~> 0.7)
     rspec (3.6.0)
       rspec-core (~> 3.6.0)
       rspec-expectations (~> 3.6.0)
@@ -278,6 +295,12 @@ GEM
       ruby-progressbar (~> 1.7)
       unicode-display_width (~> 1.0, >= 1.0.1)
     ruby-progressbar (1.8.1)
+    ruby-trello (1.5.1)
+      activemodel (>= 3.2.0)
+      addressable (~> 2.3)
+      json
+      oauth (>= 0.4.5)
+      rest-client (~> 1.8.0)
     runcom (1.3.0)
       refinements (~> 4.2)
     sass (3.5.1)
@@ -346,6 +369,9 @@ GEM
       thread_safe (~> 0.1)
     uglifier (3.2.0)
       execjs (>= 0.3.0, < 3)
+    unf (0.1.4)
+      unf_ext
+    unf_ext (0.0.7.4)
     unicode-display_width (1.3.0)
     unicode_utils (1.4.0)
     url (0.3.2)
@@ -415,6 +441,7 @@ DEPENDENCIES
   spring-watcher-listen (~> 2.0.0)
   therubyracer
   timecop
+  trollolo!
   turbolinks (~> 5)
   uglifier (>= 1.3.0)
   web-console (>= 3.3.0)

--- a/app/models/sprint.rb
+++ b/app/models/sprint.rb
@@ -8,6 +8,19 @@ class Sprint < ApplicationRecord
     find_by('start_date <= :today AND end_date >= :today', today: Time.zone.today)
   end
 
+  def unstarted_sprint?
+    start_date.today? && !File.exist?('trollolo/burndown-data-02.yaml')
+  end
+
+  def days
+    1 + (end_date - start_date).to_i - (2 * number_weekends)
+  end
+
+  def weekend_lines
+    first_line = 6.5 - start_date.cwday
+    (0..(number_weekends - 1)).map { |i| first_line + (i * 5) }.join(' ')
+  end
+
   private
 
   def starts_on_weekday
@@ -20,6 +33,10 @@ class Sprint < ApplicationRecord
 
   def create_meetings
     CreateMeetings.run(self)
+  end
+
+  def number_weekends
+    end_date.cweek - start_date.cweek
   end
 end
 

--- a/app/views/sprints/index.html.slim
+++ b/app/views/sprints/index.html.slim
@@ -10,6 +10,11 @@
                 = sprint.name
                 .description
                   = "#{sprint.start_date.strftime("%d-%m-%Y")} until #{sprint.end_date.strftime("%d-%m-%Y")}"
+                  span style="padding-left: 10px;"
+                    - if sprint.unstarted_sprint?
+                      = link_to sprint_start_path(sprint) do
+                        i.video.play.icon
+                        'Start sprint
                   span.action.right.floated
                     = link_to edit_sprint_path(sprint) do
                       i.write.icon

--- a/config/environment.rb
+++ b/config/environment.rb
@@ -3,3 +3,5 @@ require_relative 'application'
 
 # Initialize the Rails application.
 Rails.application.initialize!
+
+ENV["TROLLOLO_CONFIG_PATH"] = Rails.root.to_s + '/trollolo/.trollolorc'

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -6,7 +6,9 @@ Rails.application.routes.draw do
 
   resources :dashboards
   resources :calendars, only: :index
-  resources :sprints
+  resources :sprints do
+    get :start
+  end
   resources :meetings
   resources :absences
   namespace :team do

--- a/provisioning/bootstrap.sh
+++ b/provisioning/bootstrap.sh
@@ -7,7 +7,12 @@ zypper -q ar -f http://download.opensuse.org/repositories/devel:/languages:/ruby
 zypper -q --gpg-auto-import-keys --non-interactive ref
 zypper -q -n in -t pattern devel_basis
 zypper -q -n in libopenssl-devel readline-devel \
-    postgresql94-server postgresql94-devel libxml2-devel libxslt-devel ruby2.4-devel
+    postgresql94-server postgresql94-devel libxml2-devel libxslt-devel ruby2.4-devel \
+    python-matplotlib python-matplotlib-tk python-PyYAML
+
+# Download font needed by Trollolo to avoid warnings
+wget -O ~/.fonts/Humor-Sans.ttf "https://github.com/shreyankg/xkcd-desktop/raw/master/Humor-Sans.ttf"
+rm ~/.cache/matplotlib/fontList.cache
 
 # postgresql
 echo -e "\nsetting up postgresl...\n"

--- a/trollolo/.trollolorc.example
+++ b/trollolo/.trollolorc.example
@@ -1,0 +1,2 @@
+developer_public_key: WRITE HERE YOUR TRELLO KEY
+member_token: WRITE HERE YOUR TRELLO TOKEN

--- a/trollolo/burndown-data-01.yaml
+++ b/trollolo/burndown-data-01.yaml
@@ -1,0 +1,4 @@
+---
+meta:
+  board_id: Fs7boVwI
+  sprint: 1


### PR DESCRIPTION
There is still work to do, but If I wait until everything is completely finished before sending a PR it would huge and difficult to review and this can be merged independently. :bowtie: 

I add Trollolo configuration. I am using a version from Github, when I am completely finish I'll release the gem instead and take it from Rubygems, but I already released three times and I always find something else to change :wink: 

I also implemented Sprint feature. A link to start the sprint is shown in the `Sprint#index` page, on the
Sprint which starts today. When clicking the link the Sprint:

- The burndown data file the Sprint will be generated.
- Initial burndown char will be plotted.
- The ploted burndown char will be upload to the first Done column in
  Trello.

Work still to do:

- Program the burndown char update.
- Push burndown char to github.
- Show a hint of whar Start sprint exactly means.
- Release new version of Trollolo.

This will make more efficient our scrum process. It is part of https://github.com/openSUSE/agile-team-dashboard/issues/15
