### PR TITLE
Relax commit subject prefix whitelist in Git Cop

### DIFF
--- a/git-cop_configuration.yml
+++ b/git-cop_configuration.yml
@@ -52,9 +52,23 @@
   :whitelist:
     - Add
     - Change
+    - Complete
+    - Configure
+    - Create
+    - Delete
     - Disable
+    - Document
     - Enable
+    - Fix
+    - Improve
+    - Join
+    - Make
+    - Modify
+    - Move
+    - Refactor
+    - Relax
     - Remove
+    - Split
     - Use
     - Update
 :commit_subject_suffix:


### PR DESCRIPTION
Out intention is to ensure that the commit message start with a verb in the imperative mode, not to limit people eloquence. :bowtie: 