### PR TITLE
event's title changed to user's name

### DIFF
--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -21,7 +21,7 @@ class Event < ApplicationRecord
   # Instance methods
   #
   def title
-    [user.try(:github_login), event_type].reject(&:blank?).join(' - ')
+    [user.name, event_type].reject(&:blank?).join(' - ')
   end
 
   def all_day?

--- a/spec/models/event_spec.rb
+++ b/spec/models/event_spec.rb
@@ -17,7 +17,7 @@ RSpec.describe Meeting, type: :model do
     let(:user)  { create(:user) }
     let(:event) { create(:event, user: user) }
 
-    it { expect(event.title).to eq("#{user.github_login} - #{event.event_type}") }
+    it { expect(event.title).to eq("#{user.name} - #{event.event_type}") }
   end
 
   context '#all_day?' do


### PR DESCRIPTION
calender's event title changed from github to user's name
from what i can understand , I just changed one line for resolving issue#70.
this is my first time contribution, please do tell me if I am wrong somewhere :sweat_smile: