### PR TITLE
 Render burndown chart in the main page

### DIFF
--- a/app/controllers/sprints_controller.rb
+++ b/app/controllers/sprints_controller.rb
@@ -46,7 +46,11 @@ class SprintsController < ApplicationController
     # Generate new sprint, paint burndown char and upload it to Trello
     system 'trollolo burndown --new_sprint --plot-to-board --output=trollolo '\
             "--total_days=#{@sprint.days} --weekend_lines=#{@sprint.weekend_lines} --sprint-number=#{@sprint.number}"
-    unless $CHILD_STATUS.success?
+    image_name = "trollolo/burndown-#{@sprint.number}.png"
+    if $CHILD_STATUS.success? && File.exist?(image_name)
+      # TODO: implement this in Trollolo so we don't need to move the file afterwards
+      system "mv #{image_name} public/burndown.png"
+    else
       file_name = "trollolo/burndown-data-#{@sprint.number}.yaml"
       File.delete(file_name) if File.exist?(file_name)
       flash[:error] = 'Something went wrong, the new sprint was not generated'

--- a/app/views/dashboards/index.html.slim
+++ b/app/views/dashboards/index.html.slim
@@ -1,6 +1,10 @@
 .ui.stackable.column.grid
   .two.column.row
     .column
+      .ui.stackable.column.grid
+        .column
+          - if File.exist?('public/burndown.png')
+              = image_tag "/burndown.png", class: 'ui fluid rounded image'
       .ui.stackable.three.column.grid
         - if @meetings
           .column

--- a/config/clock.rb
+++ b/config/clock.rb
@@ -18,7 +18,8 @@ module Clockwork
     # as they shouldn't overlap. Also, there should be only one active Sprint.
     if standups.any? || reviews.any?
       system "trollolo burndown --plot-to-board --output=trollolo --sprint-number=#{Sprint.current.number}"
-      if $CHILD_STATUS.success?
+      image_name = "trollolo/burndown-#{Sprint.current.number}.png"
+      if $CHILD_STATUS.success? && File.exist?(image_name)
         Rails.logger.info 'Burndown chart updated!'
 
         # Upload to Github and delete local files on end of Sprint
@@ -45,6 +46,8 @@ module Clockwork
             Rails.logger.error 'There was an error and the burndown chart was NOT uploaded to Github'
           end
         end
+        # TODO: implement this in Trollolo so we don't need to move the file afterwards
+        system "mv #{image_name} public/burndown.png"
       else
         Rails.logger.error 'There was an error and the burndown chart was NOT updated'
       end


### PR DESCRIPTION
 Render the last generated burndown chart in the main page.
![image](https://user-images.githubusercontent.com/16052290/31676287-68d8ee9e-b367-11e7-898d-1bc6c67d7160.png)


