### PR TITLE
Show all Absences this week in dashboard.

### DIFF
--- a/app/controllers/dashboards_controller.rb
+++ b/app/controllers/dashboards_controller.rb
@@ -2,7 +2,7 @@
 class DashboardsController < ApplicationController
   def index
     @sprint = Sprint.current
-    @absences = Absence.today
+    @absences = Absence.week
     @meetings = Meeting.today
     pull_requests = PullRequest.from_github_repository('openSUSE/open-build-service')
     @pull_requests = {}

--- a/app/models/absence.rb
+++ b/app/models/absence.rb
@@ -1,7 +1,7 @@
 class Absence < Event
   validates :start_date, :end_date, :event_type, presence: true
 
-  scope :today, (-> { where('start_date <= :today AND end_date >= :today', today: Time.zone.today) })
+  scope :week, (-> { where('start_date <= ? AND end_date >= ?', Date.current + 6.days, Date.current) })
 
   # Contants
   #

--- a/app/views/dashboards/index.html.slim
+++ b/app/views/dashboards/index.html.slim
@@ -22,7 +22,7 @@
         - if @absences
           .column
             h3.ui.top.attached.header
-              | Today absences
+              | Absences this week
             .ui.divided.list.attached.segment
               - @absences.each do |absence|
                 .item

--- a/spec/models/absence_spec.rb
+++ b/spec/models/absence_spec.rb
@@ -13,26 +13,26 @@ RSpec.describe Absence, type: :model do
     it { expect(Absence::TYPES.count).to eq(4) }
   end
 
-  describe 'scope today' do
+  describe 'scope week' do
     let!(:vacation1) do
       create(:absence, event_type: :vacation, start_date: Time.zone.today - 1.hour, end_date: Time.zone.today)
     end
     let!(:vacation2) do
-      create(:absence, event_type: :vacation, start_date: Time.zone.today - 3, end_date: Time.zone.today)
+      create(:absence, event_type: :vacation, start_date: Time.zone.today - 3, end_date: Time.zone.today + 6)
     end
     let!(:vacation3) do
       create(:absence, event_type: :vacation, start_date: Time.zone.today, end_date: Time.zone.today + 5)
     end
     let!(:vacation4) do
-      create(:absence, event_type: :vacation, start_date: Time.zone.today - 6, end_date: Time.zone.today + 5)
+      create(:absence, event_type: :vacation, start_date: Time.zone.today - 6, end_date: Time.zone.today)
     end
     let!(:sick1) do
       create(:absence, event_type: :sick, start_date: Time.zone.today - 6, end_date: Time.zone.today - 1)
     end
     let!(:sick2) do
-      create(:absence, event_type: :sick, start_date: Time.zone.today + 3, end_date: Time.zone.today + 10)
+      create(:absence, event_type: :sick, start_date: Time.zone.today + 8, end_date: Time.zone.today + 10)
     end
 
-    it { expect(Absence.today).to match_array([vacation1, vacation2, vacation3, vacation4]) }
+    it { expect(Absence.week).to match_array([vacation1, vacation2, vacation3, vacation4]) }
   end
 end


### PR DESCRIPTION
Use scope to get all absences in next 7 days.
Fixes #14 

A bit confusion here though the issue states all absences this week, but here we are showing upcoming absences in next 7 days including today, unlike public holidays(which shows present week for the whole week) but I think it makes sense to show upcoming absences only.

Here's  a screenshot:
![screenshot from 2018-01-03 11-17-11](https://user-images.githubusercontent.com/26951824/34510348-2a3034a0-f079-11e7-99e1-dbf050bb14c0.png)
