### PR TITLE
Show Github member's picture 

### DIFF
--- a/app/views/team/members/_member.html.slim
+++ b/app/views/team/members/_member.html.slim
@@ -1,0 +1,17 @@
+= link_to team_member_path(member), class: 'image' do
+  - if member.gravatar_url
+    = image_tag member.gravatar_url
+  - elsif member.github_login.present?
+    = avatar(member)
+  - else
+    = image_tag 'no-image.png'
+.content
+  .header= member.fullname
+  .meta
+    span= "from #{member.location}"
+  .meta
+    = github_link_to member.github_login
+  .meta
+    = mail_to member.email do
+      i.mail.icon
+      = member.email

--- a/app/views/team/members/edit.html.slim
+++ b/app/views/team/members/edit.html.slim
@@ -2,23 +2,7 @@
   .six.wide.column
     .ui.centered.cards
       .card
-        = link_to team_member_path(@member), class: 'image' do
-          - if @member.gravatar_url
-            = image_tag @member.gravatar_url
-          - elsif @member.github_login.present?
-            = avatar(@member)
-          - else
-            = image_tag 'no-image.png'
-        .content
-          .header= @member.fullname
-          .meta
-            span= "from #{@member.location}"
-          .meta
-            = github_link_to @member.github_login
-          .meta
-            = mail_to @member.email do
-              i.mail.icon
-              = @member.email
+        = render partial: 'member', locals: { member: @member }
 
   .ten.wide.column
     .ui.segment

--- a/app/views/team/members/edit.html.slim
+++ b/app/views/team/members/edit.html.slim
@@ -5,6 +5,8 @@
         = link_to team_member_path(@member), class: 'image' do
           - if @member.gravatar_url
             = image_tag @member.gravatar_url
+          - elsif @member.github_login.present?
+            = avatar(@member)
           - else
             = image_tag 'no-image.png'
         .content

--- a/app/views/team/members/index.html.slim
+++ b/app/views/team/members/index.html.slim
@@ -4,6 +4,8 @@
       = link_to team_member_path(member), class: 'image' do
         - if member.gravatar_url
           = image_tag member.gravatar_url
+        - elsif member.github_login.present?
+          = avatar(member)
         - else
           = image_tag 'no-image.png'
       .content

--- a/app/views/team/members/index.html.slim
+++ b/app/views/team/members/index.html.slim
@@ -1,20 +1,4 @@
 .ui.centered.cards
   - @members.each do |member|
     .card
-      = link_to team_member_path(member), class: 'image' do
-        - if member.gravatar_url
-          = image_tag member.gravatar_url
-        - elsif member.github_login.present?
-          = avatar(member)
-        - else
-          = image_tag 'no-image.png'
-      .content
-        .header= member.fullname
-        .meta
-          span= "from #{member.location}"
-        .meta
-          = github_link_to member.github_login
-        .meta
-          = mail_to member.email do
-            i.mail.icon
-            = member.email
+      = render partial: 'member', locals: { member: member }


### PR DESCRIPTION
Show Github member's picture (if configured) in `/team/members` and `team/members/:id/edit`.

![screenshot from 2018-02-28 12-05-32](https://user-images.githubusercontent.com/1212806/36784455-b7e1949c-1c7f-11e8-82ba-2ff3ead1c90d.png)


Supersedes https://github.com/openSUSE/agile-team-dashboard/pull/109.

Closes #108.